### PR TITLE
🐛 Add Guard Clauses to builtLockdownLog->failed_login method

### DIFF
--- a/classes/security/class-lockdown-log.php
+++ b/classes/security/class-lockdown-log.php
@@ -27,9 +27,14 @@ class builtLockdownLog {
      * @since   2.0.0
      */
     public function failed_login() {
+        if ( ! isset( $_POST['log'] ) )
+            return;
 
         // Get user ID from login.
         $user = get_user_by( 'login', $_POST['log'] );
+
+        if ( ! $user )
+            return;
 
         // Set data.
         $data = [


### PR DESCRIPTION
## What Type of Change is This?
- [x] 🐛 Bug fix

---

## 🔎 Overview 
### Current Issue
* Some instances where `$_POST['log']` is not defined in `builtLockdownLog->failed_login()` method.
* [LEA-129](https://builtmighty.atlassian.net/browse/LEA-129)

### What is the solution or new behavior? _(If this is a a feature change...)_
* Added Guard clause and check for this array element before continuing in method, as well as a check for if `$user` was retrieved before continuing on in function.
  

---

### 📖 Git Flow Reference
```mermaid
flowchart LR
    A[[feature/1234_branch]] --> B{{Merge via PR}}
    B --> C[[rc/x.x.x]]
    C --> D{Run CI/CD?}
    D -->|fa:fa-x Fail Code Checks| E[Commit Fixes] --> D
    D -->|fa:fa-check Pass Code Checks| F[Merge Commit]
    F --> G{ Q/A }
    G --> H{{Merge via PR}}
    H --> I[[main]]
```





[LEA-129]: https://builtmighty.atlassian.net/browse/LEA-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ