### PR TITLE
✨ Added Site Logger Cron which pings Builtmighty's API Daily to record Active Site

### DIFF
--- a/builtmighty-kit.php
+++ b/builtmighty-kit.php
@@ -3,7 +3,7 @@
 Plugin Name: 🔨 Built Mighty Kit
 Plugin URI: https://builtmighty.com
 Description: A kit for Built Mighty clients and developers.
-Version: 4.0.4
+Version: 4.1.0
 Author: Built Mighty
 Author URI: https://builtmighty.com
 Copyright: Built Mighty
@@ -31,7 +31,7 @@ if( ! defined( 'WPINC' ) ) { die; }
  *
  * @since   1.0.0
  */
-define( 'KIT_VERSION', '4.0.4' );
+define( 'KIT_VERSION', '4.1.0' );
 define( 'KIT_NAME', 'builtmighty-kit' );
 define( 'KIT_PATH', trailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'KIT_URI', trailingslashit( plugin_dir_url( __FILE__ ) ) );

--- a/builtmighty-kit.php
+++ b/builtmighty-kit.php
@@ -35,6 +35,7 @@ define( 'KIT_VERSION', '4.1.0' );
 define( 'KIT_NAME', 'builtmighty-kit' );
 define( 'KIT_PATH', trailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'KIT_URI', trailingslashit( plugin_dir_url( __FILE__ ) ) );
+defined( 'KIT_FILE' ) || define( 'KIT_FILE', __FILE__ );
 
 /**
  * On activation.
@@ -110,6 +111,7 @@ function load() {
     require_once KIT_PATH . 'private/class-actionscheduler.php';
     require_once KIT_PATH . 'private/class-notifications.php';
     require_once KIT_PATH . 'private/class-speed.php';
+    require_once KIT_PATH . 'private/class-active-site-logger.php';
 
     /**
      * Initiate.

--- a/builtmighty-kit.php
+++ b/builtmighty-kit.php
@@ -61,6 +61,9 @@ function deactivation() {
     // Flush rewrite rules.
     flush_rewrite_rules();
 
+    // Call logger deactivation.
+    \BuiltMightyKit\Private\active_site_logger::deactivate();
+
 }
 
 /**

--- a/init.php
+++ b/init.php
@@ -73,6 +73,7 @@ class Plugin {
         $this->load_class( \BuiltMightyKit\Private\actionscheduler::class );
         $this->load_class( \BuiltMightyKit\Private\notifications::class );
         $this->load_class( \BuiltMightyKit\Private\speed::class );
+        $this->load_class( \BuiltMightyKit\Private\active_site_logger::class );
 
     }
 

--- a/private/class-active-site-logger.php
+++ b/private/class-active-site-logger.php
@@ -15,7 +15,38 @@ if( ! defined( 'WPINC' ) ) { die; }
 
 class active_site_logger {
 
+    /**
+     * Cron hook name.
+     *
+     * @since 4.1.0
+     * 
+     * @var string
+     */
     const CRON_HOOK = 'builtmightykit_daily_ping';
+
+    /**
+     * Instance.
+     *
+     * @since 4.1.0
+     * 
+     * @var self
+     */
+    public $instance;
+
+    /**
+     * Get the instance of the class.
+     *
+     * @since 4.1.0
+     * 
+     * @return self
+     */
+    public static function get_instance() {
+        static $instance = null;
+        if ( null === $instance ) {
+            $instance = new self();
+        }
+        return $instance;
+    }
 
     /**
      * Constructor.
@@ -61,7 +92,7 @@ class active_site_logger {
      * 
      * @hook - action - deactivate
      */
-    public function deactivate() {
+    public static function deactivate() {
         wp_clear_scheduled_hook( self::CRON_HOOK );
     }
 

--- a/private/class-active-site-logger.php
+++ b/private/class-active-site-logger.php
@@ -88,6 +88,18 @@ class active_site_logger {
         $endpoint = 'https://builtmighty.com/wp-json/builtmighty-kit/v1/active';
 
         // Send the request.
-        wp_remote_post( $endpoint, $args );
+        $response = wp_remote_post( $endpoint, $args );
+
+        // Check for errors.
+        if ( is_wp_error( $response ) ) {
+            error_log( 'Error sending ping: ' . $response->get_error_message() );
+            return;
+        }
+
+        // Check for unsuccessful HTTP status codes.
+        $status_code = wp_remote_retrieve_response_code( $response );
+        if ( $status_code < 200 || $status_code >= 300 ) {
+            error_log( 'Ping failed with status code: ' . $status_code );
+        }
     }
 }

--- a/private/class-active-site-logger.php
+++ b/private/class-active-site-logger.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Active Site Logger.
+ *
+ * Logs active sites to Built Mighty daily.
+ *
+ * @package Built Mighty Kit
+ * @since   4.1.0
+ */
+
+namespace BuiltMightyKit\Private;
+
+// Exit if accessed directly.
+if( ! defined( 'WPINC' ) ) { die; }
+
+class active_site_logger {
+
+    const CRON_HOOK = 'builtmightykit_daily_ping';
+
+    /**
+     * Constructor.
+     *
+     * @since 4.1.0
+     * 
+     * @return void
+     */
+    public function __construct() {
+
+        // Register cron event.
+        add_action( 'init', [ $this, 'schedule_cron' ] );
+
+        // Clear cron event on deactivation.
+        register_deactivation_hook( KIT_PATH . KIT_FILE, [ $this, 'deactivate' ] );
+
+        // Add cron callback.
+        add_action( self::CRON_HOOK, [ $this, 'send_ping' ] );
+
+    }
+
+    /**
+     * Activate the plugin.
+     *
+     * @since 4.1.0
+     * 
+     * @return void
+     * 
+     * @hooked - action - init
+     */
+    public function schedule_cron() {
+        if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+            wp_schedule_event( time(), 'daily', self::CRON_HOOK );
+        }
+    }
+
+    /**
+     * Deactivate the plugin.
+     *
+     * @since 4.1.0
+     * 
+     * @return void
+     * 
+     * @hook - action - deactivate
+     */
+    public function deactivate() {
+        wp_clear_scheduled_hook( self::CRON_HOOK );
+    }
+
+    /**
+     * Send a ping to Built Mighty.
+     *
+     * @since 4.1.0
+     * 
+     * @return void
+     * 
+     * @hooked - action - builtmightykit_daily_ping
+     */
+    public function send_ping() {
+        $body = [
+            'site'    => get_site_url(),
+            'context' => 'builtmightykit',
+        ];
+        $args = [
+            'body'        => wp_json_encode( $body ),
+            'headers'     => [ 'Content-Type' => 'application/json' ],
+            'timeout'     => 10,
+            'data_format' => 'body',
+        ];
+        $endpoint = 'https://builtmighty.com/wp-json/builtmighty-kit/v1/active';
+
+        // Send the request.
+        wp_remote_post( $endpoint, $args );
+    }
+}


### PR DESCRIPTION
## What Type of Change is This?
- [x] ✨ Introduced New Features

---

This pull request updates the `Built Mighty Kit` plugin to version 4.1.0 and introduces a new feature for logging active sites daily. The most significant changes include the addition of the `active_site_logger` class, updates to the plugin's versioning, and integration of the new logger into the plugin's initialization process.

### Version Update:
* Updated the plugin version from `4.0.4` to `4.1.0` in the plugin metadata and `KIT_VERSION` constant. [[1]](diffhunk://#diff-08f0f3f9d5af96df00a1a7e875f53553651a9c4bc688d31d7e76310a56b0d3a1L6-R6) [[2]](diffhunk://#diff-08f0f3f9d5af96df00a1a7e875f53553651a9c4bc688d31d7e76310a56b0d3a1L34-R38)

### New Feature: Active Site Logger
* Added a new class `active_site_logger` in `private/class-active-site-logger.php` to log active sites daily. It includes functionality for scheduling a daily cron job, sending a ping to Built Mighty's API, and clearing the cron job on deactivation.
* Registered the `active_site_logger` class in the plugin's initialization process by adding it to both the `load()` and `init_classes()` methods. [[1]](diffhunk://#diff-08f0f3f9d5af96df00a1a7e875f53553651a9c4bc688d31d7e76310a56b0d3a1R114) [[2]](diffhunk://#diff-df264b2fa3997fcbb5026196ea7463043ca8fc681f794b4d188b69a762c90eaeR76)

These changes enhance the plugin's functionality by providing a mechanism to monitor active sites, improving its utility for developers and clients.

---

### 📖 Git Flow Reference
```mermaid
flowchart LR
    A[[feature/1234_branch]] --> B{{Merge via PR}}
    B --> C[[rc/x.x.x]]
    C --> D{Run CI/CD?}
    D -->|fa:fa-x Fail Code Checks| E[Commit Fixes] --> D
    D -->|fa:fa-check Pass Code Checks| F[Merge Commit]
    F --> G{ Q/A }
    G --> H{{Merge via PR}}
    H --> I[[main]]
```



