### PR TITLE
🐛 Lazy-load vendor autoloader to avoid plugin conflicts

### DIFF
--- a/builtmighty-kit.php
+++ b/builtmighty-kit.php
@@ -3,7 +3,7 @@
 Plugin Name: 🔨 Built Mighty Kit
 Plugin URI: https://builtmighty.com
 Description: A kit for Built Mighty clients and developers.
-Version: 5.0.2
+Version: 5.0.3
 Author: Built Mighty
 Author URI: https://builtmighty.com
 Copyright: Built Mighty
@@ -31,7 +31,7 @@ if( ! defined( 'WPINC' ) ) { die; }
  *
  * @since   1.0.0
  */
-define( 'KIT_VERSION', '5.0.1' );
+define( 'KIT_VERSION', '5.0.3' );
 define( 'KIT_NAME', 'builtmighty-kit' );
 define( 'KIT_PATH', trailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'KIT_URI', trailingslashit( plugin_dir_url( __FILE__ ) ) );
@@ -104,7 +104,6 @@ function load() {
      * @since   1.0.0
      */
     require_once KIT_PATH . 'init.php';
-    require_once KIT_PATH . 'vendor/autoload.php';
     require_once KIT_PATH . 'public/class-public.php';
     require_once KIT_PATH . 'public/class-security.php';
     require_once KIT_PATH . 'public/class-login.php';

--- a/public/class-login-security.php
+++ b/public/class-login-security.php
@@ -264,6 +264,10 @@ class login_security {
         // Get secret.
         $secret = $this->auth->generate_secret( $user );
 
+        // Load BaconQrCode dependencies only when needed to avoid
+        // autoloader conflicts with other plugins using older versions.
+        require_once KIT_PATH . 'vendor/autoload.php';
+
         // Create QR code using BaconQrCode (SVG).
         $renderer = new ImageRenderer(
             new RendererStyle( 200 ),


### PR DESCRIPTION
## What Type of Change is This?
- [x] 🐛 Bug fix
- [ ] ✨ Introduced New Features
- [ ] 🔌 Plugin Updates
- [ ] 🚑 Critical Hotfix
- [ ] ♻️ Change or Refactor to Existing Feature
- [ ] 🤕 Patch Fix
- [ ] 🔒️ Security Updates
- [ ] 👷 Deploy/Build System
- [ ] 🔊 Add Logging
- [ ] 🧟‍♂️ Remove Dead Code
- [ ] 📸 Capturing Uncommitted Code

---

## 🔎 Overview
### What is the current issue or behavior?
* The `vendor/autoload.php` file was loaded globally on every page load, causing potential conflicts with other plugins that bundle older versions of the same dependencies (e.g., BaconQrCode).

### What is the solution or new behavior?
* Moved the `require_once` for `vendor/autoload.php` from the global plugin load in `builtmighty-kit.php` to inside the QR code generation method in `class-login-security.php`
* The autoloader now only loads when 2FA QR code generation is actually needed, avoiding conflicts with other plugins
* Updated version from 5.0.2 to 5.0.1

---

## 👷 Deployment Notes/Testing Steps
- [ ] Step 1 - Navigate to WP Admin and verify no PHP errors on dashboard
- [ ] Step 2 - Navigate to WP Admin → Users → Profile (or Security settings)
- [ ] Step 3 - Enable 2FA and verify the QR code generates correctly
- [ ] Step 4 - Verify other plugins that use BaconQrCode or similar libraries still function
- [ ] Step 5 - Verify no autoloader-related fatal errors on any frontend pages